### PR TITLE
Call callback function after storage.set

### DIFF
--- a/src/Framework/Sources/JavaScript/Background/background.js
+++ b/src/Framework/Sources/JavaScript/Background/background.js
@@ -61,8 +61,7 @@ function manageRequest(payload) {
     }
 
     if (payload.eventName === 'storage.set') {
-        chrome.storage[payload.message.area].set(payload.message.items);
-        sendResponse();
+        chrome.storage[payload.message.area].set(payload.message.items, sendResponse);
     }
 
     if (payload.eventName === 'storage.remove') {

--- a/src/Framework/Sources/JavaScript/Background/chrome/storage.js
+++ b/src/Framework/Sources/JavaScript/Background/chrome/storage.js
@@ -68,7 +68,7 @@ function storage(storageArea) {
             }
             callbackFunc(result);
         },
-        set(items) {
+        set(items, callbackFunc) {
             const changes = {};
             for (const key of Object.keys(items)) {
                 const oldValue = localStorage.getItem(key);
@@ -100,6 +100,7 @@ function storage(storageArea) {
                     });
                 });
             });
+            callbackFunc && callbackFunc();
         },
         remove,
         /**

--- a/src/Framework/Sources/JavaScript/Content/chrome/storage.js
+++ b/src/Framework/Sources/JavaScript/Content/chrome/storage.js
@@ -25,9 +25,6 @@ function storage(storageArea) {
             );
         },
         set(items,callback) {
-            if (callback) {
-                chrome.storage.onChanged.addListener(notify);
-            }
             background.dispatchRequest(
                 {
                     eventName: 'storage.set',
@@ -35,12 +32,9 @@ function storage(storageArea) {
                         area: storageArea,
                         items
                     }
-                }
+                },
+                () => callback()
             );
-            function notify() {
-                callback();
-                chrome.storage.onChanged.removeListener(notify);
-            }
         },
         remove(keys, callback) {
             background.dispatchRequest(

--- a/src/Framework/Sources/JavaScript/Popup/chrome/storage.js
+++ b/src/Framework/Sources/JavaScript/Popup/chrome/storage.js
@@ -24,7 +24,7 @@ function storage(storageArea) {
                 (resp) => callback(resp)
             );
         },
-        set(items) {
+        set(items, callback) {
             window.topee.dispatchRequest(
                 0,
                 {
@@ -33,8 +33,8 @@ function storage(storageArea) {
                         area: storageArea,
                         items
                     }
-                }
-                // (resp) => callback(resp)
+                },
+                () => callback()
             );
         },
         remove(keys, callback) {


### PR DESCRIPTION
As described in [Chrome API](https://developer.chrome.com/apps/storage), the storage.set method should take an empty callback as parameter.