### PR TITLE
do not use local storage

### DIFF
--- a/src/Framework/Sources/JavaScript/Background/chrome/storage.js
+++ b/src/Framework/Sources/JavaScript/Background/chrome/storage.js
@@ -4,6 +4,8 @@ const tabs = require('./tabs.js');
 const EventEmitter = require('events');
 const changeEmitter = new EventEmitter();
 
+window._storageData = window._storageData || {};
+
 function storage(storageArea) {
     const STORAGE_KEY_PREFIX = '__topee_internal.' + storageArea + '.';
     function keyName(key) {
@@ -11,7 +13,7 @@ function storage(storageArea) {
     }
 
     function getAllKeys() {
-        return Object.keys(localStorage)
+        return Object.keys(window._storageData)
             .filter(function (key) {
                 return key.startsWith(STORAGE_KEY_PREFIX);
             })
@@ -39,7 +41,7 @@ function storage(storageArea) {
                 type: 'chromeStorage',
                 key: btoa(fullKey)
             });
-        localStorage.removeItem(fullKey);
+            delete window._storageData[fullKey];
         }
         callbackFunc && callbackFunc();
     }
@@ -68,7 +70,7 @@ function storage(storageArea) {
             }
             const result = {};
             for (const key of keysToFetch) {
-                const inStorage = localStorage.getItem(keyName(key));
+                const inStorage = window._storageData[keyName(key)];
                 result[key] = inStorage ? JSON.parse(inStorage) : defaults[key] || null;
             }
             callbackFunc(result);
@@ -76,7 +78,7 @@ function storage(storageArea) {
         set(items, callbackFunc) {
             const changes = {};
             for (const key of Object.keys(items)) {
-                const oldValue = localStorage.getItem(key);
+                const oldValue = window._storageData[key];
                 const newValue = items[key];
                 const fullKey = keyName(key);
                 const strValue = JSON.stringify(items[key]);
@@ -87,7 +89,7 @@ function storage(storageArea) {
                     value: btoa(strValue)
                 });
             
-                localStorage.setItem(fullKey, strValue);
+                window._storageData[fullKey] = strValue;
                 changes[key] = { oldValue, newValue };
             }
 

--- a/src/Framework/Sources/Swift/Public/SafariExtensionBridge.swift
+++ b/src/Framework/Sources/Swift/Public/SafariExtensionBridge.swift
@@ -437,7 +437,7 @@ public class SafariExtensionBridge: NSObject, SafariExtensionBridgeType, WKScrip
             }
         }
         itemJson += "}"
-        return "(function () {var storageItems=" + itemJson + "; for (var key in storageItems){localStorage.setItem(atob(key), atob(storageItems[key]));}})();";
+        return "(function () {window._storageData={};var storageItems=" + itemJson + "; for (var key in storageItems){window._storageData[atob(key)]=atob(storageItems[key]);}})();";
     }
 
     private func sendMessageToBackgroundScript(payload: String) {


### PR DESCRIPTION
@pavelstudeny here's my fix. runtime.js still uses `localStorage` to store the current version and trigger the "install" event. I think it should be replaced as well.