### PR TITLE
storage: fix setting of 'undefined' in topee storage

### DIFF
--- a/src/Framework/Sources/JavaScript/Background/chrome/storage.js
+++ b/src/Framework/Sources/JavaScript/Background/chrome/storage.js
@@ -83,6 +83,13 @@ function storage(storageArea) {
                 const fullKey = keyName(key);
                 const strValue = JSON.stringify(items[key]);
 
+                changes[key] = { oldValue, newValue };
+
+                if (newValue === undefined) {
+                    remove(key);
+                    continue;
+                }
+
                 window.webkit.messageHandlers.appex.postMessage({
                     type: 'chromeStorage',
                     key: btoa(encodeURIComponent(fullKey)),
@@ -90,7 +97,6 @@ function storage(storageArea) {
                 });
             
                 window._storageData[fullKey] = strValue;
-                changes[key] = { oldValue, newValue };
             }
 
             changeEmitter.emit('storage', changes, storageArea);


### PR DESCRIPTION
@pavelstudeny If you store an `undefined` value in the storage, it causes an exception when being read (through `get()`).

that's because
```
JSON.stringify(undefined);
```

by its nature returns `undefined` which is then somewhere cast to a string: `"undefined"` and stored as such. A 

```
JSON.parse("undefined");
```

during `get()` it will then throw an exception:
```
Uncaught SyntaxError: "undefined" is not valid JSON
```

To solve this, we simply remove the key from the storage (instead of setting it) when its new value is `undefined`.